### PR TITLE
Caller identification & registration

### DIFF
--- a/lib/active_monitoring/runtime/flow.ex
+++ b/lib/active_monitoring/runtime/flow.ex
@@ -77,12 +77,7 @@ defmodule ActiveMonitoring.Runtime.Flow do
   defp fetch_or_insert_call(call_sid, from, campaign_id) do
     case fetch_call(call_sid) do
       nil ->
-        case fetch_subject(from, campaign_id) do
-          nil ->
-            Call.changeset(%Call{}, %{sid: call_sid, campaign_id: campaign_id, from: from}) |> Repo.insert!
-          subject ->
-            Call.changeset(%Call{}, %{sid: call_sid, subject_id: subject.id, campaign_id: campaign_id, from: from}) |> Repo.insert!
-        end
+        Call.changeset(%Call{}, %{sid: call_sid, campaign_id: campaign_id, from: from}) |> Repo.insert!
       call ->
         call
     end

--- a/lib/active_monitoring/runtime/flow.ex
+++ b/lib/active_monitoring/runtime/flow.ex
@@ -48,7 +48,7 @@ defmodule ActiveMonitoring.Runtime.Flow do
   defp action_for(step) do
     case step do
       step when step in ["welcome", "educational"] -> :play
-      step when step in ["forward"] -> :forward
+      step when step in ["registration", "forward"] -> :forward
       step when step in ["thanks"] -> :hangup
       _ -> :gather
     end

--- a/lib/active_monitoring/runtime/flow.ex
+++ b/lib/active_monitoring/runtime/flow.ex
@@ -38,6 +38,8 @@ defmodule ActiveMonitoring.Runtime.Flow do
 
   defp data_for(:forward, campaign, step, language), do:
     %{audio: Campaign.audio_for(campaign, step, language), number: campaign.forwarding_number}
+  defp data_for(:gather, campaign, "identify", language), do:
+    %{audio: Campaign.audio_for(campaign, "identify", language), finish_on_key: "#"}
   defp data_for(_action, campaign, step, language), do:
     %{audio: Campaign.audio_for(campaign, step, language)}
 

--- a/lib/active_monitoring/runtime/twiml.ex
+++ b/lib/active_monitoring/runtime/twiml.ex
@@ -11,6 +11,12 @@ defmodule ActiveMonitoring.Runtime.TwiML do
         |> generate
   end
 
+  def build({:gather, %{audio: audio_uuid, finish_on_key: finish_key}}, callback_url) do
+    gather(callback_url, finish_key, [ play(audio_uuid) ])
+      |> response
+      |> generate
+  end
+
   def build({:gather, %{audio: audio_uuid}}, callback_url) do
     gather(callback_url, [ play(audio_uuid) ])
       |> response
@@ -39,6 +45,10 @@ defmodule ActiveMonitoring.Runtime.TwiML do
 
   defp play(audio_uuid) do
     element(:Play, audio_url_for(audio_uuid))
+  end
+
+  defp gather(callback_url, finish_key, children) do
+    element(:Gather, %{method: "POST", action: callback_url, finishOnKey: finish_key}, children)
   end
 
   defp gather(callback_url, children) do

--- a/lib/active_monitoring/runtime/twiml.ex
+++ b/lib/active_monitoring/runtime/twiml.ex
@@ -12,7 +12,8 @@ defmodule ActiveMonitoring.Runtime.TwiML do
   end
 
   def build({:gather, %{audio: audio_uuid, finish_on_key: finish_key}}, callback_url) do
-    gather(callback_url, finish_key, [ play(audio_uuid) ])
+    [ gather(callback_url, finish_key, [ play(audio_uuid) ]),
+      redirect("#{callback_url}?Digits=") ]
       |> response
       |> generate
   end

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -167,7 +167,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
     end
 
     test "it should answer with registration message", %{response: response} do
-      assert {:gather, %{audio: "id-registration-es"}} = response
+      assert {:forward, %{audio: "id-registration-es", number: "5550000"}} = response
     end
   end
 

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -128,7 +128,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
       {:ok, campaign: campaign, call: call, response: response, subject: subject}
     end
 
-    test "it should advance current step" do
+    test "it should move on to the first symptom" do
       assert %Call{current_step: "symptom:id-fever"} = Repo.one!(Call)
     end
 
@@ -154,7 +154,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
       {:ok, campaign: campaign, call: call, response: response}
     end
 
-    test "it should advance current step" do
+    test "it should advance the call to registration" do
       assert %Call{current_step: "registration"} = Repo.one!(Call)
     end
 
@@ -166,7 +166,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
       assert %CallLog{step: "identify", digits: "123", call_id: ^call_id} = (CallLog |> Query.last |> Repo.one!)
     end
 
-    test "it should answer with registration message", %{response: response} do
+    test "it should forward the call for registration", %{response: response} do
       assert {:forward, %{audio: "id-registration-es", number: "5550000"}} = response
     end
   end

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -114,7 +114,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
     end
 
     test "it should answer with identify message", %{response: response} do
-      assert {:gather, %{audio: "id-identify-es"}} = response
+      assert {:gather, %{audio: "id-identify-es", finish_on_key: "#"}} = response
     end
   end
 
@@ -190,7 +190,7 @@ defmodule ActiveMonitoring.Runtime.FlowTest do
     end
 
     test "it should answer with identify message", %{response: response} do
-      assert {:gather, %{audio: "id-identify-es"}} = response
+      assert {:gather, %{audio: "id-identify-es", finish_on_key: "#"}} = response
     end
   end
 

--- a/test/lib/runtime/twiml_test.exs
+++ b/test/lib/runtime/twiml_test.exs
@@ -17,7 +17,7 @@ defmodule ActiveMonitoring.Runtime.TwimlTest do
 
     test "it should build a gather step with finish key" do
       xml = TwiML.build({:gather, %{audio: "AUDIO_UUID", finish_on_key: "*"}}, "CALLBACK_URL")
-      assert "<Response>\n\t<Gather action=\"CALLBACK_URL\" finishOnKey=\"*\" method=\"POST\">\n\t\t<Play>http://test.example.com/api/v1/audios/AUDIO_UUID</Play>\n\t</Gather>\n</Response>" == xml
+      assert "<Response>\n\t<Gather action=\"CALLBACK_URL\" finishOnKey=\"*\" method=\"POST\">\n\t\t<Play>http://test.example.com/api/v1/audios/AUDIO_UUID</Play>\n\t</Gather>\n\t<Redirect>CALLBACK_URL?Digits=</Redirect>\n</Response>" == xml
     end
 
     test "it should build a forward step" do

--- a/test/lib/runtime/twiml_test.exs
+++ b/test/lib/runtime/twiml_test.exs
@@ -15,6 +15,11 @@ defmodule ActiveMonitoring.Runtime.TwimlTest do
       assert "<Response>\n\t<Gather action=\"CALLBACK_URL\" method=\"POST\">\n\t\t<Play>http://test.example.com/api/v1/audios/AUDIO_UUID</Play>\n\t</Gather>\n</Response>" == xml
     end
 
+    test "it should build a gather step with finish key" do
+      xml = TwiML.build({:gather, %{audio: "AUDIO_UUID", finish_on_key: "*"}}, "CALLBACK_URL")
+      assert "<Response>\n\t<Gather action=\"CALLBACK_URL\" finishOnKey=\"*\" method=\"POST\">\n\t\t<Play>http://test.example.com/api/v1/audios/AUDIO_UUID</Play>\n\t</Gather>\n</Response>" == xml
+    end
+
     test "it should build a forward step" do
       xml = TwiML.build({:forward, %{audio: "AUDIO_UUID", number: "5550000"}}, "CALLBACK_URL")
       assert "<Response>\n\t<Play>http://test.example.com/api/v1/audios/AUDIO_UUID</Play>\n\t<Dial>5550000</Dial>\n\t<Redirect>CALLBACK_URL</Redirect>\n</Response>" == xml

--- a/test/models/campaign_test.exs
+++ b/test/models/campaign_test.exs
@@ -11,7 +11,7 @@ defmodule ActiveMonitoring.CampaignTest do
   end
 
   test "generate steps from symptoms", context do
-    assert ["language", "welcome", "symptom:id-fever", "symptom:id-rash", "forward", "educational", "thanks"] == Campaign.steps(context[:campaign])
+    assert ["language", "welcome", "identify", "registration", "symptom:id-fever", "symptom:id-rash", "forward", "educational", "thanks"] == Campaign.steps(context[:campaign])
   end
 
   test "returns audio for language topic", context do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -29,7 +29,7 @@ defmodule ActiveMonitoring.Factory do
     topics =
       campaign.symptoms
       |> Enum.map(fn([id, _]) -> "symptom:#{id}" end)
-      |> Enum.concat(["welcome", "forward", "additional_information_intro", "educational", "thanks"])
+      |> Enum.concat(["welcome", "identify", "registration", "forward", "additional_information_intro", "educational", "thanks"])
 
     lang_audios =
       for lang <- campaign.langs,

--- a/web/models/call.ex
+++ b/web/models/call.ex
@@ -44,6 +44,11 @@ defmodule ActiveMonitoring.Call do
     |> select([r], %{x: (fragment("date_part('week', ?)", (field(r, ^date_field)))), y: count("*")})
   end
 
+  def assign_subject(call, subject) do
+    changeset(call, %{subject_id: subject.id})
+    |> Repo.update!
+  end
+
   defp render_one(call) do
     %{
       id: call.id,

--- a/web/models/campaign.ex
+++ b/web/models/campaign.ex
@@ -35,13 +35,17 @@ defmodule ActiveMonitoring.Campaign do
     |> assoc_constraint(:user)
   end
 
-  def steps(%{symptoms: symptoms, additional_information: additional_information}) do
+  def symptom_steps(%{symptoms: symptoms}) do
+    Enum.map(symptoms, fn([id, _]) -> "symptom:#{id}" end)
+  end
+
+  def steps(%{symptoms: symptoms, additional_information: additional_information} = campaign) do
     Enum.concat([
       ["language",
        "welcome",
        "identify",
        "registration"],
-      Enum.map(symptoms, fn([id, _]) -> "symptom:#{id}" end),
+      symptom_steps(campaign),
       ["forward",
        (if additional_information == "optional", do: "additional_information_intro"),
        (if additional_information in ["optional", "compulsory"], do: "educational"),

--- a/web/models/campaign.ex
+++ b/web/models/campaign.ex
@@ -38,7 +38,9 @@ defmodule ActiveMonitoring.Campaign do
   def steps(%{symptoms: symptoms, additional_information: additional_information}) do
     Enum.concat([
       ["language",
-       "welcome"],
+       "welcome",
+       "identify",
+       "registration"],
       Enum.map(symptoms, fn([id, _]) -> "symptom:#{id}" end),
       ["forward",
        (if additional_information == "optional", do: "additional_information_intro"),

--- a/web/static/js/components/campaigns/UploadAudioStep.jsx
+++ b/web/static/js/components/campaigns/UploadAudioStep.jsx
@@ -34,6 +34,10 @@ class UploadAudioStepComponent extends Component {
   getTopicTexts(topic) {
     if (topic == 'welcome') {
       return { title: 'Welcome message', description: 'Present the objectives of this call' }
+    } else if (topic == 'identify') {
+      return { title: 'Identify message', description: 'Ask subject to dial their ID or to press # if they do not have one' }
+    } else if (topic == 'registration') {
+      return { title: 'Registration message', description: 'Inform the caller the call will be forwarded to an agent for registration' }
     } else if (topic == 'forward') {
       return { title: 'Forward call message', description: 'Explain that the current call will be forwarded to an agent due to positive symptoms' }
     } else if (topic == 'educational') {

--- a/web/static/js/selectors/campaign.js
+++ b/web/static/js/selectors/campaign.js
@@ -5,7 +5,7 @@ export const audioEntries = (campaign: Campaign): { [lang: string]: string[] } =
   const langs = campaign.langs.filter((lang) => lang && lang != '')
 
   const symptoms = (campaign.symptoms || []).filter(([id, name]) => name && name != '').map(([id, name]) => `symptom:${id}`)
-  let topics = ['welcome'].concat(symptoms).concat(['forward', 'additional_information_intro', 'educational', 'thanks'])
+  let topics = ['welcome', 'identify', 'registration'].concat(symptoms).concat(['forward', 'additional_information_intro', 'educational', 'thanks'])
   if (campaign.additionalInformation == 'zero' || campaign.additionalInformation == undefined) {
     const i = topics.indexOf('additional_information_intro')
     topics.splice(i, 2)


### PR DESCRIPTION
Ask callers to identify themselves, and forward the call to an agent if they are not registered yet.

Fixes #51