### PR TITLE
Fix Campaign load after going back to Campaign index

### DIFF
--- a/web/static/js/actions/campaign.js
+++ b/web/static/js/actions/campaign.js
@@ -3,6 +3,7 @@ import { SERVER_ERROR } from './shared'
 import { push } from 'react-router-redux'
 import assign from 'lodash/assign'
 
+export const CAMPAIGN_CLEAR = 'CAMPAIGN_CLEAR'
 export const CAMPAIGN_CREATE = 'CAMPAIGN_CREATE'
 export const CAMPAIGN_CREATED = 'CAMPAIGN_CREATED'
 export const CAMPAIGN_FETCH = 'CAMPAIGN_FETCH'
@@ -10,6 +11,10 @@ export const CAMPAIGN_FETCHED = 'CAMPAIGN_FETCHED'
 export const CAMPAIGN_UPDATE = 'CAMPAIGN_UPDATE'
 export const CAMPAIGN_UPDATED = 'CAMPAIGN_UPDATED'
 export const CAMPAIGN_LAUNCH = 'CAMPAIGN_LAUNCH'
+
+export const campaignClear = () => (dispatch) => {
+  dispatch({type: CAMPAIGN_CLEAR})
+}
 
 export const createCampaign = (campaignParams) => (dispatch) => {
   dispatch({type: CAMPAIGN_CREATE})

--- a/web/static/js/components/campaigns/Campaigns.jsx
+++ b/web/static/js/components/campaigns/Campaigns.jsx
@@ -101,6 +101,7 @@ class Campaigns extends Component {
   }
 
   goToCampaign(id) {
+    this.props.itemActions.campaignClear()
     this.props.navigate(`/campaigns/${id}`)
   }
 

--- a/web/static/js/reducers/campaign.js
+++ b/web/static/js/reducers/campaign.js
@@ -11,6 +11,7 @@ const initialState = {
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case actions.CAMPAIGN_CLEAR: return campaignClear(state, action)
     case actions.CAMPAIGN_CREATED: return campaignLoaded(state, action)
     case actions.CAMPAIGN_FETCH: return campaignFetch(state, action)
     case actions.CAMPAIGN_FETCHED: return campaignLoaded(state, action)
@@ -21,6 +22,10 @@ export default (state = initialState, action) => {
     default: return state
   }
 }
+
+const campaignClear = (state) => (
+  { fetching: false, campaignId: null, data: null }
+)
 
 const campaignFetch = (state, id) => {
   return { fetching: true, campaignId: id, data: null }


### PR DESCRIPTION
The `goToCampaign` function dispatchs a navigation event, which in turn dispatchs a `CAMPAIGN_FETCH` event that clears `state.campaign`. But the `CAMPAIGN_FETCH` event is processed _after_ rendering the `Campaign` control.

So when the user is at the index and navigates to a campaign, the `render` method sees that `state.campaign.data` is `null`, and renders an empty page. Then the `CAMPAIGN_FETCH` and `CAMPAIGN_FETCHED` resolve, correctly rendering everything.

But if the user hits the browser's back button, `state.campaign.data` is still populated - and doesn't get nulled. When the user clicks the next Campaign to see, it navigates, and the `render` method sees `state.campaign.data` with the old data - and then it crashes.

This commit clears `state.campaign.data` before navigating, so the issue is avoided at all.

Fixes #63